### PR TITLE
Fix quiz results recommendation display

### DIFF
--- a/web/app/start-from-scratch/quiz/page.tsx
+++ b/web/app/start-from-scratch/quiz/page.tsx
@@ -272,6 +272,7 @@ export default function BasicsQuizPage() {
         throw new Error("Invalid MCQ payload");
       }
       const generated: QuizQuestion = {
+        topic: "generated question",
         prompt: payload.prompt,
         choices: payload.choices.map(String),
         correctIndex: payload.correctIndex,
@@ -605,10 +606,6 @@ export default function BasicsQuizPage() {
             <p className="mt-1 font-semibold text-gray-900">
               Total score: {totalScore} / {TOTAL_MCQ + codingChallenges.length}
             </p>
-            <button
-              className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-              onClick={handleRestart}
-            >
             {weakTopics.length > 0 ? (
               <div className="mt-4 rounded-md border border-yellow-200 bg-yellow-50 p-4">
                 <p className="font-semibold text-gray-900">Topics to review</p>
@@ -633,7 +630,7 @@ export default function BasicsQuizPage() {
             <button
               className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
               onClick={handleRestart}
-            ></button>
+            >
               Retake full quiz
             </button>
           </div>


### PR DESCRIPTION
## Summary
Fixes the quiz completion UI so the weak-topic recommendation card displays separately from the retake button.

Also adds a fallback topic label for generated questions so the quiz result recommendation logic has a valid topic value.

## Testing
- Checked `quiz/page.tsx` with editor diagnostics; no linter errors were reported for the file.