### PR TITLE
Add QA harness for the curated coding-problem banks

### DIFF
--- a/web/app/api/dev/audit-banks/route.ts
+++ b/web/app/api/dev/audit-banks/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { auditCuratedBanks } from "@/lib/numpy-bank-audit";
+
+/**
+ * Dev-only QA endpoint: statically audits the curated coding-problem banks and
+ * returns a JSON report. Runnable headlessly during `next dev`:
+ *
+ *   curl -s http://localhost:3000/api/dev/audit-banks | jq
+ *
+ * Returns HTTP 200 when every check passes, 500 otherwise — usable as a guard.
+ * Solvability (running each problem through the real grader) is verified by the
+ * browser page at /dev/bank-check, since Pyodide is browser-only.
+ */
+export async function GET() {
+  const report = auditCuratedBanks();
+  return NextResponse.json(report, { status: report.ok ? 200 : 500 });
+}

--- a/web/app/dev/bank-check/page.tsx
+++ b/web/app/dev/bank-check/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * Dev-only QA harness for the curated coding-problem banks.
+ *
+ * Two layers of verification:
+ *  1. Static audit (auditCuratedBanks) — ids, structure, anti-shortcut gate.
+ *  2. Solvability — each problem's reference solution is executed through the
+ *     SAME Pyodide grader learners use; a problem only passes if the grader
+ *     reports `passed`. This catches broken Python assertions that static
+ *     checks can't see.
+ *
+ * Not linked from the app; visit /dev/bank-check during `next dev`.
+ */
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { CURATED_CODE_CHALLENGES } from "@/lib/numpy-code-challenge-quality";
+import {
+  auditCuratedBanks,
+  referenceSolutionFor,
+  type BankAuditReport,
+} from "@/lib/numpy-bank-audit";
+import { toWorkerChecks } from "@/lib/numpy-code-validate";
+import { validatePythonInWorker } from "@/lib/pyodide-web-worker";
+
+type SolveStatus = "pending" | "running" | "pass" | "fail";
+
+type SolveRow = {
+  id: string;
+  topic: string;
+  status: SolveStatus;
+  detail: string;
+};
+
+const STATUS_STYLE: Record<SolveStatus, string> = {
+  pending: "bg-slate-100 text-slate-500",
+  running: "bg-amber-100 text-amber-800",
+  pass: "bg-emerald-100 text-emerald-800",
+  fail: "bg-rose-100 text-rose-800",
+};
+
+export default function BankCheckPage() {
+  // Pure, module-data-only computations — safe as lazy initializers (no
+  // setState-in-effect needed, runs once on first render).
+  const [audit] = useState<BankAuditReport>(() => auditCuratedBanks());
+  const [rows, setRows] = useState<SolveRow[]>(() =>
+    CURATED_CODE_CHALLENGES.map((c) => ({
+      id: c.id,
+      topic: c.topic,
+      status: "pending",
+      detail: "",
+    })),
+  );
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      for (const c of CURATED_CODE_CHALLENGES) {
+        if (cancelled) return;
+        setRows((prev) =>
+          prev.map((r) => (r.id === c.id ? { ...r, status: "running" } : r)),
+        );
+
+        let status: SolveStatus = "fail";
+        let detail = "";
+        const solution = referenceSolutionFor(c.id);
+        if (!solution) {
+          detail = "no reference solution";
+        } else {
+          try {
+            const res = await validatePythonInWorker(solution, toWorkerChecks(c.checks));
+            if (!res.ok) {
+              detail = `runner error: ${res.error}`;
+            } else if (res.error) {
+              detail = `${res.error.type}: ${res.error.message}`;
+            } else if (!res.passed) {
+              detail = res.failures.map((f) => f.message).join("; ") || "checks failed";
+            } else {
+              status = "pass";
+              detail = "solvable + graded correctly";
+            }
+          } catch (e) {
+            detail = `runner error: ${e instanceof Error ? e.message : String(e)}`;
+          }
+        }
+
+        if (cancelled) return;
+        setRows((prev) =>
+          prev.map((r) => (r.id === c.id ? { ...r, status, detail } : r)),
+        );
+      }
+      if (!cancelled) setDone(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const passCount = rows.filter((r) => r.status === "pass").length;
+  const failCount = rows.filter((r) => r.status === "fail").length;
+  const staticIssues = audit?.results.filter((r) => r.issues.length > 0) ?? [];
+  const allGreen =
+    audit?.ok === true && done && failCount === 0 && rows.length > 0;
+
+  return (
+    <main className="mx-auto max-w-4xl p-6 md:p-10">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-bold text-slate-900">Curated bank QA</h1>
+        <Link href="/dashboard" className="text-sm text-sky-700 hover:underline">
+          ← Back to app
+        </Link>
+      </div>
+      <p className="mt-2 text-sm text-slate-600">
+        Static audit + live Pyodide solvability check for every curated coding problem.
+      </p>
+
+      {/* Overall banner */}
+      <div
+        className={`mt-6 rounded-2xl border p-4 text-sm font-medium ${
+          !done
+            ? "border-amber-200 bg-amber-50 text-amber-800"
+            : allGreen
+              ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+              : "border-rose-200 bg-rose-50 text-rose-800"
+        }`}
+      >
+        {!done
+          ? "Running solvability checks in Pyodide…"
+          : allGreen
+            ? `All ${rows.length} curated problems pass static audit and solve correctly.`
+            : `Problems found — ${failCount} solvability failure(s), ${staticIssues.length} static issue(s).`}
+      </div>
+
+      {/* Static audit summary */}
+      {audit && (
+        <section className="mt-6">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+            Static audit
+          </h2>
+          <ul className="mt-2 space-y-1 text-sm text-slate-700">
+            <li>Curated challenges: {audit.totalCurated}</li>
+            <li>Curriculum challenges: {audit.totalCurriculum}</li>
+            <li>
+              Duplicate ids:{" "}
+              {audit.duplicateIds.length === 0 ? "none" : audit.duplicateIds.join(", ")}
+            </li>
+          </ul>
+          {staticIssues.length > 0 && (
+            <ul className="mt-3 space-y-2">
+              {staticIssues.map((r) => (
+                <li
+                  key={r.id}
+                  className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800"
+                >
+                  <span className="font-mono font-semibold">{r.id}</span>:{" "}
+                  {r.issues.join("; ")}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+
+      {/* Solvability table */}
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Solvability ({passCount}/{rows.length} passing)
+        </h2>
+        <ul className="mt-2 divide-y divide-slate-100 rounded-2xl border border-slate-200">
+          {rows.map((r) => (
+            <li key={r.id} className="flex items-center gap-3 p-3 text-sm">
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-semibold ${STATUS_STYLE[r.status]}`}
+              >
+                {r.status}
+              </span>
+              <span className="font-mono text-slate-900">{r.id}</span>
+              <span className="text-slate-400">·</span>
+              <span className="text-slate-600">{r.topic}</span>
+              {r.detail && (
+                <span className="ml-auto truncate pl-3 text-xs text-slate-500">
+                  {r.detail}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/lib/numpy-bank-audit.ts
+++ b/web/lib/numpy-bank-audit.ts
@@ -1,0 +1,145 @@
+/**
+ * Dev-only audit harness for the curated coding-problem banks.
+ *
+ * The curated challenges feed the *fallback* code lab (used when the AI is
+ * unavailable), so a malformed problem can't break the happy path — but it can
+ * still ship a broken drill. This module is the guard against that:
+ *
+ *  1. `auditCuratedBanks()` — pure, UI-free static checks (no Pyodide):
+ *     unique ids, ≥2 checks with the required fields, a captured result check,
+ *     a non-empty starter + reference solution, and that every problem passes
+ *     the SAME `isWeakCodeChallenge` anti-shortcut gate the generator enforces.
+ *  2. `REFERENCE_SOLUTIONS` — a known-correct solution per curated id, used by
+ *     the `/dev/bank-check` page to execute each problem through the real
+ *     Pyodide grader and prove it is solvable and graded correctly.
+ *
+ * Nothing here is imported by the learner-facing app at runtime.
+ */
+import {
+  CURATED_CODE_CHALLENGES,
+  isWeakCodeChallenge,
+  type CuratedCodeChallenge,
+} from "@/lib/numpy-code-challenge-quality";
+import { allCurriculumCodeChallenges } from "@/lib/numpy-code-topics";
+
+/**
+ * Known-correct solution for every curated challenge id. Solutions assign the
+ * source variable(s) and `answer`; `np` is already in the grading namespace, so
+ * the explicit import is only there to keep each solution self-contained.
+ */
+export const REFERENCE_SOLUTIONS: Record<string, string> = {
+  // ── pre-existing curated challenges ────────────────────────────────────────
+  "slice-middle": "import numpy as np\na = np.array([10, 20, 30, 40, 50])\nanswer = a[1:4]",
+  "boolean-mask": "import numpy as np\na = np.array([3, 7, 2, 9, 4])\nanswer = a[a > 5]",
+  "reshape-arange": "import numpy as np\na = np.arange(6)\nanswer = a.reshape(3, 2)",
+  "column-newaxis": "import numpy as np\na = np.array([1, 2, 3])\nanswer = a[:, np.newaxis]",
+  "sum-reduction": "import numpy as np\nx = np.array([1, 2, 3, 4])\nanswer = x.sum()",
+  "shape-from-array":
+    "import numpy as np\nm = np.array([[1, 2, 3], [4, 5, 6]])\nanswer = m.shape",
+  // ── added curated challenges ───────────────────────────────────────────────
+  "mean-reduction": "import numpy as np\nx = np.array([2, 4, 6, 8])\nanswer = x.mean()",
+  "max-reduction": "import numpy as np\nx = np.array([7, 3, 9, 2, 5])\nanswer = x.max()",
+  "min-reduction": "import numpy as np\nx = np.array([7, 3, 9, 2, 5])\nanswer = x.min()",
+  "broadcast-add-scalar": "import numpy as np\nx = np.array([1, 2, 3, 4])\nanswer = x + 10",
+  "broadcast-multiply-scalar": "import numpy as np\nx = np.array([1, 2, 3, 4])\nanswer = x * 3",
+  "elementwise-add-two":
+    "import numpy as np\na = np.array([1, 2, 3])\nb = np.array([10, 20, 30])\nanswer = a + b",
+  "transpose-matrix":
+    "import numpy as np\nm = np.array([[1, 2, 3], [4, 5, 6]])\nanswer = m.T",
+  "flatten-2d": "import numpy as np\nm = np.array([[1, 2], [3, 4]])\nanswer = m.flatten()",
+  "reverse-1d": "import numpy as np\nx = np.array([1, 2, 3, 4, 5])\nanswer = x[::-1]",
+  "sort-1d": "import numpy as np\nx = np.array([4, 1, 3, 2])\nanswer = np.sort(x)",
+  "unique-values": "import numpy as np\nx = np.array([1, 2, 2, 3, 3, 3])\nanswer = np.unique(x)",
+  "where-indices":
+    "import numpy as np\nx = np.array([5, 12, 7, 20, 3])\nanswer = np.where(x > 8)[0]",
+  "concatenate-two":
+    "import numpy as np\na = np.array([1, 2, 3])\nb = np.array([4, 5, 6])\nanswer = np.concatenate([a, b])",
+  "vstack-two":
+    "import numpy as np\na = np.array([1, 2, 3])\nb = np.array([4, 5, 6])\nanswer = np.vstack([a, b])",
+  "linspace-build": "import numpy as np\nanswer = np.linspace(0, 1, 5)",
+  "dot-product":
+    "import numpy as np\na = np.array([1, 2, 3])\nb = np.array([4, 5, 6])\nanswer = a.dot(b)",
+};
+
+export function referenceSolutionFor(id: string): string | null {
+  return REFERENCE_SOLUTIONS[id] ?? null;
+}
+
+export type ChallengeAuditResult = {
+  id: string;
+  topic: string;
+  /** Empty when the challenge passes every static check. */
+  issues: string[];
+};
+
+export type BankAuditReport = {
+  ok: boolean;
+  totalCurated: number;
+  totalCurriculum: number;
+  /** Ids that appear more than once across curated + curriculum challenges. */
+  duplicateIds: string[];
+  results: ChallengeAuditResult[];
+};
+
+/** Static checks for a single curated challenge (no code execution). */
+function auditChallenge(c: CuratedCodeChallenge): ChallengeAuditResult {
+  const issues: string[] = [];
+
+  if (typeof c.starterCode !== "string" || c.starterCode.trim() === "") {
+    issues.push("missing starterCode");
+  }
+  if (!Array.isArray(c.checks) || c.checks.length < 2) {
+    issues.push("needs at least 2 checks (source + result)");
+  } else {
+    c.checks.forEach((check, i) => {
+      if (!check.id?.trim()) issues.push(`check[${i}] missing id`);
+      if (!check.assert?.trim()) issues.push(`check[${i}] missing assert`);
+      if (!check.message?.trim()) issues.push(`check[${i}] missing message`);
+    });
+    const hasCapturedResult = c.checks.some((check) => check.capture?.trim());
+    if (!hasCapturedResult) {
+      issues.push("no check captures a value (need a result check with `capture`)");
+    }
+  }
+
+  // Reuse the production anti-shortcut gate so curated content can never drift
+  // below what the generator is held to.
+  const gate = isWeakCodeChallenge(c.prompt, c.checks ?? []);
+  if (gate) issues.push(`quality gate: ${gate}`);
+
+  const solution = REFERENCE_SOLUTIONS[c.id];
+  if (typeof solution !== "string" || solution.trim() === "") {
+    issues.push("missing reference solution (add to REFERENCE_SOLUTIONS)");
+  } else if (!/\banswer\b/.test(solution)) {
+    issues.push("reference solution never assigns `answer`");
+  }
+
+  return { id: c.id, topic: c.topic, issues };
+}
+
+/**
+ * Audit the curated bank plus curriculum-derived challenges. Returns a report;
+ * `ok` is true only when there are no duplicate ids and every curated challenge
+ * passes all static checks.
+ */
+export function auditCuratedBanks(): BankAuditReport {
+  const curriculum = allCurriculumCodeChallenges();
+
+  // Duplicate-id detection across both pools.
+  const counts = new Map<string, number>();
+  for (const c of [...CURATED_CODE_CHALLENGES, ...curriculum]) {
+    counts.set(c.id, (counts.get(c.id) ?? 0) + 1);
+  }
+  const duplicateIds = [...counts.entries()].filter(([, n]) => n > 1).map(([id]) => id);
+
+  const results = CURATED_CODE_CHALLENGES.map(auditChallenge);
+  const ok = duplicateIds.length === 0 && results.every((r) => r.issues.length === 0);
+
+  return {
+    ok,
+    totalCurated: CURATED_CODE_CHALLENGES.length,
+    totalCurriculum: curriculum.length,
+    duplicateIds,
+    results,
+  };
+}


### PR DESCRIPTION
Adds a dev-only QA harness that statically audits the curated coding-problem
banks and runs every reference solution through the real Pyodide grader to
prove each problem is solvable and graded correctly.

Test plan:
- npm run build passes
- GET /api/dev/audit-banks returns {"ok":true,...}
- /dev/bank-check shows all rows green ("solvable + graded correctly")

Closes #56 