### PR TITLE
keyboard shortcuts for MCQ quiz navigation

### DIFF
--- a/web/app/find-my-level/page.tsx
+++ b/web/app/find-my-level/page.tsx
@@ -419,6 +419,25 @@ export default function FindMyLevelPage() {
     };
   }, []);
 
+  // Keyboard shortcuts: 1-4 selects an answer, Enter advances after answering
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (phase !== "mcq") return;
+      if (e.key === "Enter" && hasAnswered) {
+        if (!isLastQuestion) handleNext();
+        else moveToCodingStage();
+        return;
+      }
+      const num = parseInt(e.key, 10);
+      if (num >= 1 && num <= 4 && !hasAnswered) {
+        handleSelect(num - 1);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, hasAnswered, isLastQuestion, index]);
+
   function getWeakTopics() {
     const merged = new Map<string, number>();
     for (const [topic, count] of Object.entries(topicMistakes)) {
@@ -785,15 +804,18 @@ export default function FindMyLevelPage() {
 
         {phase === "mcq" && (
           <>
-            <p className="mt-3 text-xs text-slate-400">
-              {isPrefetchingMcq
-                ? "Preparing next question…"
-                : mcqGenerationStatus === "generated"
-                  ? "AI-generated question"
-                  : mcqGenerationStatus === "fallback"
-                    ? "Fallback question"
-                    : ""}
-            </p>
+            <div className="mt-3 flex items-center justify-between">
+              <p className="text-xs text-slate-400">
+                {isPrefetchingMcq
+                  ? "Preparing next question…"
+                  : mcqGenerationStatus === "generated"
+                    ? "AI-generated question"
+                    : mcqGenerationStatus === "fallback"
+                      ? "Fallback question"
+                      : ""}
+              </p>
+              <p className="text-xs text-slate-300">Press 1–4 to select · Enter to continue</p>
+            </div>
 
             <h2 className="mt-6 text-xl font-semibold text-gray-900">{question.prompt}</h2>
 

--- a/web/app/numpy/exercises/page.tsx
+++ b/web/app/numpy/exercises/page.tsx
@@ -235,6 +235,20 @@ function NumpyExercisesContent() {
     void loadMcq();
   }
 
+  // Keyboard nav: 1–4 to select, Enter to load next question
+  useEffect(() => {
+    if (tab !== "mcq") return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Enter" && mcqSelected !== null) { onMcqNext(); return; }
+      const n = parseInt(e.key, 10);
+      if (n >= 1 && n <= 4 && mcqSelected === null) onMcqPick(n - 1);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  // deps: tab + mcqSelected so the handler sees fresh state
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, mcqSelected]);
+
   /* —— Code lab —— */
   const [challenge, setChallenge] = useState<CodeChallenge | null>(null);
   const [codeLoading, setCodeLoading] = useState(false);


### PR DESCRIPTION
Small UX improvement — you can now press 1, 2, 3, or 4 to select an answer choice without clicking, and Enter to advance to the next question after answering.

Added to both the placement quiz and the exercises MCQ drill. Also added a subtle hint text in the placement quiz UI so people know it's there.

Useful when working through a lot of questions quickly.