### PR TITLE
show session performance alongside all-time accuracy in exercises

### DIFF
--- a/web/app/numpy/exercises/page.tsx
+++ b/web/app/numpy/exercises/page.tsx
@@ -550,9 +550,15 @@ function NumpyExercisesContent() {
                   </div>
                 </div>
               )}
+              {/* All-time vs this-session breakdown */}
               <p className="text-xs text-slate-400">
-                {summary.totalAttempted} attempts · {summary.totalCorrect} correct
+                All time: {summary.totalAttempted} attempts · {summary.totalCorrect} correct
               </p>
+              {(mcqSessionAttempted + codeSessionAttempted) > 0 && (
+                <p className="text-xs font-medium text-sky-600">
+                  This session: {mcqSessionCorrect + codeSessionCorrect}/{mcqSessionAttempted + codeSessionAttempted} correct
+                </p>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
The exercises page tracks MCQ and code session stats (correct/attempted this session) but never showed them to the user — only the all-time accuracy ring was visible.

Added a 'This session: X/Y correct' line under the all-time stat. It only appears once you've answered at least one question so it doesn't clutter a fresh session.

Useful for seeing how you're doing right now vs historically — especially helpful when drilling a specific topic and wanting quick feedback.