### PR TITLE
improve placement completion modal — level-specific message + overall %

### DIFF
--- a/web/app/find-my-level/page.tsx
+++ b/web/app/find-my-level/page.tsx
@@ -985,7 +985,13 @@ export default function FindMyLevelPage() {
         open={completion !== null}
         emoji="🏆"
         title="Placement complete!"
-        message="Nice work — here’s where you landed. Your personalized path is ready."
+        message={
+          completion?.level === "Advanced"
+            ? "Strong performance — you’re placed at Advanced. Your path starts from the tougher units."
+            : completion?.level === "Intermediate"
+              ? "Solid work — you’re placed at Intermediate. Your path skips the basics and goes right to the good stuff."
+              : "You’re placed at Beginner. Your path starts from the foundations and builds up steadily."
+        }
         highlight={completion ? { label: "Your level", value: completion.level } : undefined}
         stats={
           completion
@@ -998,8 +1004,12 @@ export default function FindMyLevelPage() {
                   label: "Code (first try)",
                   value: `${completion.codeScore} / ${completion.totalCode}`,
                 },
+                {
+                  label: "Overall",
+                  value: `${Math.round(((completion.mcqScore + completion.codeScore) / (completion.totalMcq + completion.totalCode)) * 100)}%`,
+                },
                 ...(completion.recommendedTopic
-                  ? [{ label: "Start with", value: completion.recommendedTopic }]
+                  ? [{ label: "Focus topic", value: completion.recommendedTopic }]
                   : []),
               ]
             : undefined


### PR DESCRIPTION
The completion modal was showing the same generic message regardless of what level you got. Now it shows a level-specific message that actually tells you what the result means (e.g. Advanced = 'Your path starts from the tougher units').

Also added an 'Overall %' stat so learners can see their combined MCQ + code score at a glance. The 'Start with' label was renamed to 'Focus topic' which is clearer.

Small UX polish but makes the end-of-placement moment feel more meaningful.