### PR TITLE
achievement badge system (9 badges, unlock toast, localStorage)

### DIFF
--- a/web/app/find-my-level/page.tsx
+++ b/web/app/find-my-level/page.tsx
@@ -8,6 +8,8 @@ import { canonicalizeTopic } from "@/lib/numpy-learning-path";
 import { saveNumpyPlacement } from "@/lib/numpy-placement-storage";
 import { awardXPWithResult, XP_AWARD } from "@/lib/xp-store";
 import { XPToast } from "@/components/xp-toast";
+import { BadgeToast } from "@/components/badge-toast";
+import { checkStreakBadge, checkTierBadge, tryAwardBadge, type Badge } from "@/lib/achievements";
 import { runAndValidateChallenge } from "@/lib/numpy-code-validate";
 import { ensurePyodideWorker } from "@/lib/pyodide-web-worker";
 import { MINIMAL_STARTER_CODE } from "@/lib/numpy-starter-code";
@@ -393,6 +395,7 @@ export default function FindMyLevelPage() {
   const [pyodideError, setPyodideError] = useState("");
   const canRunPython = !pyodideLoading && !pyodideError;
   const [xpToast, setXpToast] = useState<{ amount: number; levelUpTier?: { name: string; icon: string } } | null>(null);
+  const [badgeToast, setBadgeToast] = useState<Badge | null>(null);
 
   const question = currentQuestion; // Alias for readability in JSX.
   const hasAnswered = selected !== null;
@@ -579,6 +582,8 @@ export default function FindMyLevelPage() {
       setMcqScore((prev) => prev + 1);
       const r = awardXPWithResult("mcq_correct");
       setXpToast({ amount: XP_AWARD.mcq_correct, ...(r.leveledUp ? { levelUpTier: r.newTier } : {}) });
+      // First-correct badge + tier/streak checks
+      setBadgeToast((prev) => prev ?? tryAwardBadge("first-correct") ?? checkTierBadge(r.newTier.minXP) ?? checkStreakBadge(0));
     } else {
       setTopicMistakes((prev) => ({
         ...prev,
@@ -677,12 +682,14 @@ export default function FindMyLevelPage() {
               amount: XP_AWARD.code_first_try,
               ...(r1.leveledUp ? { levelUpTier: r1.newTier } : {}),
             });
+            setBadgeToast((prev) => prev ?? tryAwardBadge("first-code") ?? checkTierBadge(r1.newTier.minXP));
           } else {
             const r2 = awardXPWithResult("code_pass");
             setXpToast({
               amount: XP_AWARD.code_pass,
               ...(r2.leveledUp ? { levelUpTier: r2.newTier } : {}),
             });
+            setBadgeToast((prev) => prev ?? checkTierBadge(r2.newTier.minXP));
           }
         }
       } else if (attemptsSoFar === 0) {
@@ -746,6 +753,7 @@ export default function FindMyLevelPage() {
     });
     const rp = awardXPWithResult("placement_complete");
     setXpToast({ amount: XP_AWARD.placement_complete, ...(rp.leveledUp ? { levelUpTier: rp.newTier } : {}) });
+    setBadgeToast((prev) => prev ?? tryAwardBadge("placed") ?? checkTierBadge(rp.newTier.minXP));
     setCompletion({
       level,
       mcqScore,
@@ -1021,6 +1029,7 @@ export default function FindMyLevelPage() {
         secondaryAction={{ label: "Go to dashboard", href: "/dashboard" }}
       />
       <XPToast amount={xpToast?.amount ?? null} levelUpTier={xpToast?.levelUpTier} onDone={() => setXpToast(null)} />
+      <BadgeToast badge={badgeToast} onDone={() => setBadgeToast(null)} />
     </main>
   );
 }

--- a/web/app/numpy/exercises/page.tsx
+++ b/web/app/numpy/exercises/page.tsx
@@ -5,6 +5,8 @@ import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ExerciseProgressRing } from "@/components/exercise-progress-ring";
 import { XPToast } from "@/components/xp-toast";
+import { BadgeToast } from "@/components/badge-toast";
+import { checkTierBadge, tryAwardBadge, type Badge } from "@/lib/achievements";
 import {
   awardXPWithResult,
   XP_AWARD,
@@ -135,6 +137,7 @@ function NumpyExercisesContent() {
   const [mcqSelected, setMcqSelected] = useState<number | null>(null);
   const [seenMcqPrompts, setSeenMcqPrompts] = useState<string[]>([]);
   const [xpToast, setXpToast] = useState<{ amount: number; levelUpTier?: { name: string; icon: string } } | null>(null);
+  const [badgeToast, setBadgeToast] = useState<Badge | null>(null);
 
   const xpRecord = useSyncExternalStore(subscribeXP, getXPSnapshot, getXPServerSnapshot);
   const tier = getTierForXP(xpRecord.total);
@@ -220,6 +223,7 @@ function NumpyExercisesContent() {
         amount: XP_AWARD.mcq_correct,
         ...(result.leveledUp ? { levelUpTier: result.newTier } : {}),
       });
+      setBadgeToast((prev) => prev ?? tryAwardBadge("first-correct") ?? checkTierBadge(result.newTier.minXP));
     } else {
       setTopicMistakes((prev) => ({
         ...prev,
@@ -453,6 +457,7 @@ function NumpyExercisesContent() {
             amount: XP_AWARD[eventType],
             ...(result.leveledUp ? { levelUpTier: result.newTier } : {}),
           });
+          setBadgeToast((prev) => prev ?? tryAwardBadge("first-code") ?? checkTierBadge(result.newTier.minXP));
           recordExerciseResult(EXERCISE_ZONE_CODE_LAB, true, {
             topicKey: topicProgressKey,
           });
@@ -716,6 +721,7 @@ function NumpyExercisesContent() {
         levelUpTier={xpToast?.levelUpTier}
         onDone={() => setXpToast(null)}
       />
+      <BadgeToast badge={badgeToast} onDone={() => setBadgeToast(null)} />
     </main>
   );
 }

--- a/web/components/badge-toast.tsx
+++ b/web/components/badge-toast.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Badge } from "@/lib/achievements";
+
+type BadgeToastProps = {
+  badge: Badge | null;
+  onDone: () => void;
+};
+
+/**
+ * Bottom-left toast shown when a badge is earned for the first time.
+ * Sits opposite the XPToast (bottom-right) so they can show simultaneously.
+ */
+export function BadgeToast({ badge, onDone }: BadgeToastProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!badge) return;
+    const enter = setTimeout(() => setVisible(true), 10);
+    const exit  = setTimeout(() => { setVisible(false); setTimeout(onDone, 350); }, 2400);
+    return () => { clearTimeout(enter); clearTimeout(exit); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [badge]);
+
+  if (!badge) return null;
+
+  return (
+    <div
+      aria-live="polite"
+      className={`fixed bottom-6 left-6 z-[200] flex items-center gap-3 rounded-2xl border border-purple-200 bg-white px-5 py-3 shadow-lg transition-all duration-300 ${
+        visible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+      }`}
+    >
+      <span className="text-2xl">{badge.icon}</span>
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-purple-500">
+          Badge unlocked
+        </p>
+        <p className="text-sm font-black text-slate-900">{badge.name}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/components/lesson-practice.tsx
+++ b/web/components/lesson-practice.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { PythonCodeEditor } from "@/components/python-code";
 import { XPToast } from "@/components/xp-toast";
+import { BadgeToast } from "@/components/badge-toast";
 import type { Lesson } from "@/lib/numpy-curriculum";
 import { EXERCISE_ZONE_CODE_LAB, loadNumpyExerciseProgress, recordExerciseResult } from "@/lib/numpy-exercise-progress";
 import { slugifyTopic } from "@/lib/numpy-learning-path";
@@ -10,6 +11,7 @@ import { lessonProgress, notifyProgressChange } from "@/lib/numpy-progress-store
 import { runAndValidateChallenge } from "@/lib/numpy-code-validate";
 import { ensurePyodideWorker } from "@/lib/pyodide-web-worker";
 import { awardXPWithResult, XP_AWARD } from "@/lib/xp-store";
+import { tryAwardBadge, checkTierBadge, type Badge } from "@/lib/achievements";
 import { MINIMAL_STARTER_CODE } from "@/lib/numpy-starter-code";
 
 export function LessonPractice({ lesson }: { lesson: Lesson }) {
@@ -21,6 +23,7 @@ export function LessonPractice({ lesson }: { lesson: Lesson }) {
   const [pyodideLoading, setPyodideLoading] = useState(true);
   const [pyodideError, setPyodideError] = useState("");
   const [xpToast, setXpToast] = useState<{ amount: number; levelUpTier?: { name: string; icon: string } } | null>(null);
+  const [badgeToast, setBadgeToast] = useState<Badge | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -71,6 +74,7 @@ export function LessonPractice({ lesson }: { lesson: Lesson }) {
             amount: XP_AWARD.lesson_mastered,
             ...(result.leveledUp ? { levelUpTier: result.newTier } : {}),
           });
+          setBadgeToast((prev) => prev ?? tryAwardBadge("first-mastery") ?? checkTierBadge(result.newTier.minXP));
         }
       }
     } catch (e) {
@@ -145,6 +149,7 @@ export function LessonPractice({ lesson }: { lesson: Lesson }) {
         levelUpTier={xpToast?.levelUpTier}
         onDone={() => setXpToast(null)}
       />
+      <BadgeToast badge={badgeToast} onDone={() => setBadgeToast(null)} />
     </section>
   );
 }

--- a/web/lib/achievements.ts
+++ b/web/lib/achievements.ts
@@ -1,0 +1,166 @@
+/**
+ * Achievement badge system. Badges are earned once and stored in per-user
+ * localStorage — same scoped-key pattern as the rest of the progress stores.
+ *
+ * Callers award badges by calling tryAwardBadge(id). It returns the Badge
+ * object only the first time it's earned, so components can show a toast.
+ * Subsequent calls for the same id return null (idempotent).
+ */
+import { scopedStorageKey } from "@/lib/current-user";
+
+export type Badge = {
+  id: string;
+  icon: string;
+  name: string;
+  description: string;
+};
+
+export const ALL_BADGES: Badge[] = [
+  {
+    id: "first-correct",
+    icon: "🎯",
+    name: "First Strike",
+    description: "Got your first MCQ answer correct",
+  },
+  {
+    id: "first-code",
+    icon: "💻",
+    name: "Code Runner",
+    description: "Passed your first code challenge",
+  },
+  {
+    id: "placed",
+    icon: "🧭",
+    name: "Placed",
+    description: "Completed the placement quiz",
+  },
+  {
+    id: "first-mastery",
+    icon: "📚",
+    name: "Scholar",
+    description: "Mastered your first lesson",
+  },
+  {
+    id: "streak-3",
+    icon: "🔥",
+    name: "On Fire",
+    description: "Kept a 3-day learning streak",
+  },
+  {
+    id: "tier-bronze",
+    icon: "🥉",
+    name: "Bronze",
+    description: "Reached Bronze tier (100 XP)",
+  },
+  {
+    id: "tier-silver",
+    icon: "🥈",
+    name: "Silver",
+    description: "Reached Silver tier (300 XP)",
+  },
+  {
+    id: "tier-gold",
+    icon: "🥇",
+    name: "Gold",
+    description: "Reached Gold tier (600 XP)",
+  },
+  {
+    id: "tier-platinum",
+    icon: "💎",
+    name: "Platinum",
+    description: "Reached Platinum tier (1000 XP)",
+  },
+];
+
+const BADGES_KEY = "adapted.badges.v1";
+const BADGES_CHANGE_EVENT = "adapted-badges-change";
+
+function badgesStorageKey(): string {
+  return scopedStorageKey(BADGES_KEY);
+}
+
+function loadEarnedIds(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = localStorage.getItem(badgesStorageKey());
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw) as unknown;
+    if (!Array.isArray(arr)) return new Set();
+    return new Set((arr as unknown[]).filter((x): x is string => typeof x === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+let _cachedRaw: string | null = null;
+let _cachedValue: Badge[] | null = null;
+
+function saveEarnedIds(ids: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(badgesStorageKey(), JSON.stringify([...ids]));
+    _cachedRaw = null;
+    window.dispatchEvent(new Event(BADGES_CHANGE_EVENT));
+  } catch { /* quota */ }
+}
+
+/**
+ * Try to award a badge. Returns the Badge if this is the first time it's
+ * earned so the caller can show a notification. Returns null if already earned.
+ */
+export function tryAwardBadge(id: string): Badge | null {
+  const earned = loadEarnedIds();
+  if (earned.has(id)) return null;
+  const badge = ALL_BADGES.find((b) => b.id === id);
+  if (!badge) return null;
+  earned.add(id);
+  saveEarnedIds(earned);
+  return badge;
+}
+
+/** Award the appropriate tier badge for the given XP total. */
+export function checkTierBadge(xpTotal: number): Badge | null {
+  if (xpTotal >= 1000) return tryAwardBadge("tier-platinum");
+  if (xpTotal >= 600)  return tryAwardBadge("tier-gold");
+  if (xpTotal >= 300)  return tryAwardBadge("tier-silver");
+  if (xpTotal >= 100)  return tryAwardBadge("tier-bronze");
+  return null;
+}
+
+/** Award the streak badge when the learner hits a 3-day streak. */
+export function checkStreakBadge(streak: number): Badge | null {
+  if (streak >= 3) return tryAwardBadge("streak-3");
+  return null;
+}
+
+export function getEarnedBadges(): Badge[] {
+  const earned = loadEarnedIds();
+  return ALL_BADGES.filter((b) => earned.has(b.id));
+}
+
+// ─── React external-store adapter ────────────────────────────────────────────
+
+const EMPTY_BADGES: Badge[] = [];
+
+export function getBadgesSnapshot(): Badge[] {
+  if (typeof window === "undefined") return EMPTY_BADGES;
+  const key = badgesStorageKey();
+  const raw = `${key} ${window.localStorage.getItem(key) ?? ""}`;
+  if (raw === _cachedRaw && _cachedValue !== null) return _cachedValue;
+  _cachedRaw = raw;
+  _cachedValue = getEarnedBadges();
+  return _cachedValue;
+}
+
+export function getBadgesServerSnapshot(): Badge[] {
+  return EMPTY_BADGES;
+}
+
+export function subscribeBadges(callback: () => void): () => void {
+  window.addEventListener(BADGES_CHANGE_EVENT, callback);
+  window.addEventListener("focus", callback);
+  return () => {
+    window.removeEventListener(BADGES_CHANGE_EVENT, callback);
+    window.removeEventListener("focus", callback);
+  };
+}


### PR DESCRIPTION
Added lib/achievements.ts — a per-user badge store following the same scoped localStorage pattern as xp-store and numpy-placement-storage.

9 badges: First Strike (first correct MCQ), Code Runner (first code pass), Placed (completed placement), Scholar (first lesson mastered), On Fire (3-day streak), and one badge per XP tier (Bronze through Platinum).

tryAwardBadge(id) returns the Badge only the first time it's earned so callers can show a notification. Wired into find-my-level, exercises, and lesson-practice — each XP-earning event also checks for relevant badges.

New BadgeToast component shows at bottom-left (opposite the XPToast at bottom-right) so both can appear simultaneously without overlap.